### PR TITLE
ci: add Jenkinsfile and adjust Dockerfile for fleet deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,18 +27,25 @@ RUN ln -s /app/logos/logoscore/AppRun /bin/logoscore \
     && ln -s /app/logos/lgpm/AppRun /bin/lgpm \
     && ln -s /app/logos/lgpd/AppRun /bin/lgpd
 
-RUN mkdir -p /etc/logos/blockchain /etc/logos/persistence && chown -R ubuntu:ubuntu /etc/logos
+RUN mkdir -p /var/lib/logos/blockchain /var/lib/logos/config /var/lib/logos/persistence \
+    && usermod -u 10000 ubuntu && groupmod -g 10000 ubuntu \
+    && chown -R ubuntu:ubuntu /var/lib/logos /home/ubuntu
 
 USER ubuntu
 WORKDIR /home/ubuntu
 
+ARG DELIVERY_VERSION
+ARG STORAGE_VERSION
+ARG BLOCKCHAIN_VERSION
+ARG OPENMETRICS_VERSION
+
 RUN mkdir packages \
-    && lgpd download delivery_module --version 1.1.0 --output ./packages \
-    && lgpd download storage_module --version 1.0.0 --output ./packages \
-    && lgpd download liblogos_blockchain_module --version 1.0.0 --output ./packages \
-    && lgpd download openmetrics --version 0.1.0 --output ./packages
+    && lgpd download delivery_module --version ${DELIVERY_VERSION} --output ./packages \
+    && lgpd download storage_module --version ${STORAGE_VERSION} --output ./packages \
+    && lgpd download blockchain_module --version ${BLOCKCHAIN_VERSION} --output ./packages \
+    && lgpd download openmetrics --version ${OPENMETRICS_VERSION} --output ./packages
 
 RUN mkdir modules \
     && lgpm install --dir ./packages --modules-dir ./modules
 
-CMD ["logoscore", "-D", "-m", "/home/ubuntu/modules", "--persistence-path", "/etc/logos/persistence"]
+CMD ["logoscore", "-D", "-m", "./modules", "--config-dir", "/var/lib/logos/config", "--persistence-path", "/var/lib/logos/persistence"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM nixos/nix:2.34.1 AS builder
 RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
 WORKDIR /app
 
-RUN nix build 'github:logos-co/logos-logoscore-cli/ab6365eae7920ebf20b16f91b06295be55d55821#cli-appimage' --out-link ./logoscore --refresh
-RUN nix build 'github:logos-co/logos-package-manager/2b4b72087154dd4d6f691ac2527e06e0dadaef4d#cli-appimage' --out-link ./package-manager --refresh
-RUN nix build 'github:logos-co/logos-package-downloader/172a518450f74da820232a51cc31dd6af8d190a7#cli-appimage' --out-link ./package-downloader --refresh
+RUN nix build 'github:logos-co/logos-logoscore-cli/bae0d5440af16932327969a2aed5e2bf5d0943b0#cli-appimage' --out-link ./logoscore --refresh
+RUN nix build 'github:logos-co/logos-package-manager/205d6bb295c43e9432aef367dd32dac82e39bddf#cli-appimage' --out-link ./package-manager --refresh
+RUN nix build 'github:logos-co/logos-package-downloader/b6f46e62b625c02a9251cd40682fbf8277177d67#cli-appimage' --out-link ./package-downloader --refresh
 
 RUN mkdir -p /app-final/logos \
     && cp -rL ./logoscore/* /app-final/logos/ \
@@ -40,9 +40,9 @@ ARG BLOCKCHAIN_VERSION
 ARG OPENMETRICS_VERSION
 
 RUN mkdir packages \
-    && lgpd download delivery_module --version ${DELIVERY_VERSION} --output ./packages \
-    && lgpd download storage_module --version ${STORAGE_VERSION} --output ./packages \
-    && lgpd download blockchain_module --version ${BLOCKCHAIN_VERSION} --output ./packages \
+    && if [ -n "${DELIVERY_VERSION}" ]; then lgpd download delivery_module --version ${DELIVERY_VERSION} --output ./packages; fi \
+    && if [ -n "${STORAGE_VERSION}" ]; then lgpd download storage_module --version ${STORAGE_VERSION} --output ./packages; fi \
+    && if [ -n "${BLOCKCHAIN_VERSION}" ]; then lgpd download blockchain_module --version ${BLOCKCHAIN_VERSION} --output ./packages; fi \
     && lgpd download openmetrics --version ${OPENMETRICS_VERSION} --output ./packages
 
 RUN mkdir modules \

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,0 +1,83 @@
+#!/usr/bin/env groovy
+library 'status-jenkins-lib@v1.9.41'
+
+pipeline {
+  agent {
+    docker {
+      label 'linuxcontainer'
+      image 'harbor.status.im/infra/ci-build-containers:linux-base-1.0.0'
+      args '--volume=/var/run/docker.sock:/var/run/docker.sock ' +
+           '--user jenkins'
+    }
+  }
+
+  options {
+    timestamps()
+    ansiColor('xterm')
+    disableRestartFromStage()
+    timeout(time: 30, unit: 'MINUTES')
+    buildDiscarder(logRotator(
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
+    ))
+  }
+
+  parameters {
+    string(
+      name: 'IMAGE_TAG',
+      description: 'Name of Docker tag to push.',
+      defaultValue: getDefaultImageTag()
+    )
+    string(
+      name: 'IMAGE_NAME',
+      description: 'Name of Docker image to push.',
+      defaultValue: params.IMAGE_NAME ?: 'harbor.status.im/logos-co/logos-node',
+    )
+    string(
+      name: 'DOCKER_CRED',
+      description: 'Name of Docker Registry credential.',
+      defaultValue: params.DOCKER_CRED ?: 'harbor-logos-co-logos-node',
+    )
+    string(
+      name: 'DOCKER_REGISTRY_URL',
+      description: 'URL of the Docker Registry',
+      defaultValue: params.DOCKER_REGISTRY_URL ?: 'https://harbor.status.im'
+    )
+  }
+
+  stages {
+    stage('Build') {
+      steps { script {
+        image = docker.build(
+          "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
+          "--label=build='${env.BUILD_URL}' " +
+          "--label=commit='${git.commit()}' " +
+          "."
+        )
+      } }
+    }
+
+    stage('Push') {
+      when { expression { params.IMAGE_TAG != '' } }
+      steps { script {
+        withDockerRegistry([
+          credentialsId: params.DOCKER_CRED, url: params.DOCKER_REGISTRY_URL
+        ]) {
+          image.push()
+        }
+      } }
+    }
+  }
+
+  post {
+    always { sh 'docker image prune -f' }
+  }
+}
+
+def getDefaultImageTag() {
+  switch (env.JOB_BASE_NAME) {
+    case 'docker-latest':  return 'latest'
+    case 'docker-release': return 'stable'
+    default:               return env.JOB_BASE_NAME
+  }
+}

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -43,6 +43,26 @@ pipeline {
       description: 'URL of the Docker Registry',
       defaultValue: params.DOCKER_REGISTRY_URL ?: 'https://harbor.status.im'
     )
+string(
+      name: 'DELIVERY_VERSION',
+      description: 'Version of delivery module.',
+      defaultValue: '0.1.3'
+    )
+    string(
+      name: 'STORAGE_VERSION',
+      description: 'Version of storage module.',
+      defaultValue: '1.2.0'
+    )
+    string(
+      name: 'BLOCKCHAIN_VERSION',
+      description: 'Version of blockchain module.',
+      defaultValue: '0.2.0'
+    )
+    string(
+      name: 'OPENMETRICS_VERSION',
+      description: 'Version of openmetrics module.',
+      defaultValue: '0.1.0'
+    )
   }
 
   stages {
@@ -52,6 +72,10 @@ pipeline {
           "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
           "--label=build='${env.BUILD_URL}' " +
           "--label=commit='${git.commit()}' " +
+          "--build-arg DELIVERY_VERSION='${params.DELIVERY_VERSION}' " +
+          "--build-arg STORAGE_VERSION='${params.STORAGE_VERSION}' " +
+          "--build-arg BLOCKCHAIN_VERSION='${params.BLOCKCHAIN_VERSION}' " +
+          "--build-arg OPENMETRICS_VERSION='${params.OPENMETRICS_VERSION}' " +
           "."
         )
       } }

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -23,66 +23,84 @@ pipeline {
   }
 
   parameters {
-    string(
-      name: 'IMAGE_TAG',
-      description: 'Name of Docker tag to push.',
-      defaultValue: getDefaultImageTag()
+    choice(
+      name: 'FLEET',
+      description: 'Target fleet.',
+      choices: ['dev', 'test']
     )
     string(
-      name: 'IMAGE_NAME',
-      description: 'Name of Docker image to push.',
-      defaultValue: params.IMAGE_NAME ?: 'harbor.status.im/logos-co/logos-node',
-    )
-    string(
-      name: 'DOCKER_CRED',
-      description: 'Name of Docker Registry credential.',
-      defaultValue: params.DOCKER_CRED ?: 'harbor-logos-co-logos-node',
-    )
-    string(
-      name: 'DOCKER_REGISTRY_URL',
-      description: 'URL of the Docker Registry',
-      defaultValue: params.DOCKER_REGISTRY_URL ?: 'https://harbor.status.im'
-    )
-string(
       name: 'DELIVERY_VERSION',
-      description: 'Version of delivery module.',
+      description: 'Delivery module version. Leave empty to exclude.',
       defaultValue: '0.1.3'
     )
     string(
       name: 'STORAGE_VERSION',
-      description: 'Version of storage module.',
+      description: 'Storage module version. Leave empty to exclude.',
       defaultValue: '1.2.0'
     )
     string(
       name: 'BLOCKCHAIN_VERSION',
-      description: 'Version of blockchain module.',
+      description: 'Blockchain module version. Leave empty to exclude.',
       defaultValue: '0.2.0'
     )
     string(
       name: 'OPENMETRICS_VERSION',
-      description: 'Version of openmetrics module.',
+      description: 'Openmetrics module version. Leave empty to exclude.',
       defaultValue: '0.1.0'
+    )
+    string(
+      name: 'IMAGE_NAME',
+      description: 'Name of Docker image to push.',
+      defaultValue: 'harbor.status.im/logos-co/logos-node'
+    )
+    string(
+      name: 'DOCKER_CRED',
+      description: 'Name of Docker Registry credential.',
+      defaultValue: 'harbor-logos-co-logos-node'
+    )
+    string(
+      name: 'DOCKER_REGISTRY_URL',
+      description: 'URL of the Docker Registry',
+      defaultValue: 'https://harbor.status.im'
     )
   }
 
   stages {
     stage('Build') {
       steps { script {
+        def parts = []
+        def buildArgs = "--label=build='${env.BUILD_URL}' --label=commit='${git.commit()}' "
+
+        if (params.DELIVERY_VERSION?.trim()) {
+          parts.add("d${params.DELIVERY_VERSION}")
+          buildArgs += "--build-arg DELIVERY_VERSION='${params.DELIVERY_VERSION}' "
+          buildArgs += "--label=delivery='${params.DELIVERY_VERSION}' "
+        }
+        if (params.STORAGE_VERSION?.trim()) {
+          parts.add("s${params.STORAGE_VERSION}")
+          buildArgs += "--build-arg STORAGE_VERSION='${params.STORAGE_VERSION}' "
+          buildArgs += "--label=storage='${params.STORAGE_VERSION}' "
+        }
+        if (params.BLOCKCHAIN_VERSION?.trim()) {
+          parts.add("b${params.BLOCKCHAIN_VERSION}")
+          buildArgs += "--build-arg BLOCKCHAIN_VERSION='${params.BLOCKCHAIN_VERSION}' "
+          buildArgs += "--label=blockchain='${params.BLOCKCHAIN_VERSION}' "
+        }
+        if (params.OPENMETRICS_VERSION?.trim()) {
+          buildArgs += "--build-arg OPENMETRICS_VERSION='${params.OPENMETRICS_VERSION}' "
+        }
+
+        def tag = "${params.FLEET}-${parts.join('-')}"
+
         image = docker.build(
-          "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
-          "--label=build='${env.BUILD_URL}' " +
-          "--label=commit='${git.commit()}' " +
-          "--build-arg DELIVERY_VERSION='${params.DELIVERY_VERSION}' " +
-          "--build-arg STORAGE_VERSION='${params.STORAGE_VERSION}' " +
-          "--build-arg BLOCKCHAIN_VERSION='${params.BLOCKCHAIN_VERSION}' " +
-          "--build-arg OPENMETRICS_VERSION='${params.OPENMETRICS_VERSION}' " +
-          "."
+          "${params.IMAGE_NAME}:${tag}",
+          "${buildArgs} ."
         )
+        env.IMAGE_TAG = tag
       } }
     }
 
     stage('Push') {
-      when { expression { params.IMAGE_TAG != '' } }
       steps { script {
         withDockerRegistry([
           credentialsId: params.DOCKER_CRED, url: params.DOCKER_REGISTRY_URL
@@ -95,13 +113,5 @@ string(
 
   post {
     always { sh 'docker image prune -f' }
-  }
-}
-
-def getDefaultImageTag() {
-  switch (env.JOB_BASE_NAME) {
-    case 'docker-latest':  return 'latest'
-    case 'docker-release': return 'stable'
-    default:               return env.JOB_BASE_NAME
   }
 }


### PR DESCRIPTION
Jenkinsfile now builds tags from fleet choice and module versions
(e.g. test-d0.1.3-s1.2.0-b0.2.0). Empty version excludes module
from build. Dockerfile conditionally downloads only specified
modules.

Module versions (delivery, storage, blockchain, openmetrics) are now
configurable via Docker build args and Jenkins parameters.