### PR TITLE
Bump packages; add openmetrics module, doctest, and persistence volume

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -8,6 +8,22 @@ name: Doc-Test
 #
 # Linux only: the doc-test builds and runs a Docker image, and GitHub's macOS
 # runners have no Docker daemon.
+#
+# ──────────────────────────────────────────────────────────────────────────────
+# One-time setup for the published report links to work:
+#
+#   Repo Settings → Pages → "Build and deployment" → Source: "Deploy from a
+#   branch", Branch: `gh-pages` / `(root)`. (The publish-report job creates the
+#   gh-pages branch on its first run; Pages just needs to be pointed at it.)
+#
+# Each run publishes the two-column HTML report to:
+#   https://<owner>.github.io/<repo>/pr-<N>/     (pull requests)
+#   https://<owner>.github.io/<repo>/main/       (pushes to master/main)
+# and, for PRs, posts/updates a comment with the link.
+#
+# Fork PRs get a read-only GITHUB_TOKEN, so the Pages push and PR comment are
+# skipped for them — the downloadable artifact is still produced.
+# ──────────────────────────────────────────────────────────────────────────────
 
 on:
   pull_request:
@@ -90,3 +106,85 @@ jobs:
       - name: Tear down
         if: always()
         run: docker rm -f logos-doctest >/dev/null 2>&1 || true
+
+  publish-report:
+    name: Publish report to GitHub Pages
+    needs: doctest
+    # Run even when the doc-test fails — a failing run is exactly when you want to
+    # open the report. Skip on forks, where GITHUB_TOKEN can't push or comment.
+    if: ${{ always() && github.event.pull_request.head.repo.fork != true }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write          # push to the gh-pages branch
+      pull-requests: write      # post/update the PR comment
+
+    # Serialize Pages deploys across all runs so concurrent PRs don't race on the
+    # gh-pages branch. Not cancel-in-progress: a queued publish should still run.
+    concurrency:
+      group: gh-pages-publish
+      cancel-in-progress: false
+
+    steps:
+      - name: Download report
+        continue-on-error: true   # a cancelled doc-test may leave no artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: openmetrics-doctest-report
+          path: report
+
+      - name: Arrange site directory
+        id: arrange
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="pr-${{ github.event.pull_request.number }}"
+          else
+            BASE="main"
+          fi
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+
+          mkdir -p "site/$BASE"
+          if [ -f report/index.html ]; then
+            cp report/index.html "site/$BASE/index.html"
+          else
+            echo "<!doctype html><meta charset=utf-8><title>No report</title><h1>No report produced</h1>" > "site/$BASE/index.html"
+          fi
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          keep_files: true
+          commit_message: "Publish openmetrics doc-test report for ${{ steps.arrange.outputs.base }} (${{ github.sha }})"
+
+      - name: Comment on PR with report link
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const base = "${{ steps.arrange.outputs.base }}";
+            const { owner, repo } = context.repo;
+            const url = `https://${owner}.github.io/${repo}/${base}/`;
+            const marker = "<!-- openmetrics-doctest-report-link -->";
+            const body =
+              `${marker}\n` +
+              `### 📊 openmetrics doc-test report\n\n` +
+              `The image built from this commit, run end-to-end (build → load ` +
+              `modules → init openmetrics → scrape \`/metrics\`), rendered ` +
+              `alongside the commands actually run and their output (updated each ` +
+              `run, commit \`${context.sha.slice(0, 7)}\`):\n\n` +
+              `- [View report](${url})\n\n` +
+              `_Pages can take a minute to update after the run finishes._`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: context.issue.number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: context.issue.number, body });
+            }

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -1,0 +1,92 @@
+name: Doc-Test
+
+# Runs the executable doc-test end-to-end via the shared doctest CLI
+# (https://github.com/logos-co/logos-doctest):
+#   doctests/openmetrics.test.yaml builds the logos image from the commit under
+#   test, runs it with the OpenMetrics port published, loads the bundled modules,
+#   initializes openmetrics, and scrapes /metrics from the host.
+#
+# Linux only: the doc-test builds and runs a Docker image, and GitHub's macOS
+# runners have no Docker daemon.
+
+on:
+  pull_request:
+    branches: [master, main]
+  push:
+    branches: [master, main]
+
+concurrency:
+  group: doctests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  doctest:
+    name: openmetrics doc-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      # The doc-test builds `github:logos-co/logos-docker#<ref>` (a docker build
+      # from the GitHub repo), so resolve the commit under test and pass it via
+      # $LOGOS_DOCKER_REF — for pushes that's the pushed commit, for PRs the PR's
+      # head commit. Fork PRs are the exception: their head commit isn't in
+      # logos-co/logos-docker, so docker can't fetch it; fall back to the base
+      # branch so the doc-test still runs (against the base, not the PR's diff).
+      - name: Resolve ref under test
+        id: ref
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
+            echo "ref=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+            echo "Fork PR — building base branch '${{ github.event.pull_request.base.ref }}' (the fork's commit can't be fetched from the base repo)."
+          else
+            echo "ref=${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run the doc-test
+        env:
+          LOGOS_DOCKER_REF: ${{ steps.ref.outputs.ref }}
+        run: |
+          # Remove any stale container so --name doesn't collide (no-op on a
+          # fresh runner; matters on reruns / self-hosted).
+          docker rm -f logos-doctest >/dev/null 2>&1 || true
+          # --continue-on-fail so the run walks every step and the report is
+          # complete; the CLI still exits non-zero if any step failed.
+          nix run github:logos-co/logos-doctest -- run \
+            doctests/openmetrics.test.yaml \
+            --verbose \
+            --continue-on-fail \
+            --report "${{ runner.temp }}/openmetrics-doctest-report.html"
+
+      - name: Stage report
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p report-out
+          if [ -f "${{ runner.temp }}/openmetrics-doctest-report.html" ]; then
+            cp "${{ runner.temp }}/openmetrics-doctest-report.html" report-out/index.html
+          else
+            echo "<h1>No report produced</h1>" > report-out/index.html
+          fi
+
+      - name: Upload execution report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openmetrics-doctest-report
+          path: report-out/index.html
+          if-no-files-found: warn
+
+      - name: Tear down
+        if: always()
+        run: docker rm -f logos-doctest >/dev/null 2>&1 || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM nixos/nix:2.34.1 AS builder
 RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
 WORKDIR /app
 
-RUN nix build 'github:logos-co/logos-logoscore-cli/454e0696e9417acaac2c0b6dc1f209b5838c7635#cli-appimage' --out-link ./logoscore --refresh
-RUN nix build 'github:logos-co/logos-package-manager/a59f14eb1045df4364d8ce795498ad2e0b323e1e#cli-appimage' --out-link ./package-manager --refresh
-RUN nix build 'github:logos-co/logos-package-downloader/9f9531b82493b01c3ede0b6b5be04a7422fc6a6e#cli-appimage' --out-link ./package-downloader --refresh
+RUN nix build 'github:logos-co/logos-logoscore-cli/ab6365eae7920ebf20b16f91b06295be55d55821#cli-appimage' --out-link ./logoscore --refresh
+RUN nix build 'github:logos-co/logos-package-manager/2b4b72087154dd4d6f691ac2527e06e0dadaef4d#cli-appimage' --out-link ./package-manager --refresh
+RUN nix build 'github:logos-co/logos-package-downloader/172a518450f74da820232a51cc31dd6af8d190a7#cli-appimage' --out-link ./package-downloader --refresh
 
 RUN mkdir -p /app-final/logos \
     && cp -rL ./logoscore/* /app-final/logos/ \
@@ -27,17 +27,18 @@ RUN ln -s /app/logos/logoscore/AppRun /bin/logoscore \
     && ln -s /app/logos/lgpm/AppRun /bin/lgpm \
     && ln -s /app/logos/lgpd/AppRun /bin/lgpd
 
-RUN mkdir -p /etc/logos/blockchain && chown -R ubuntu:ubuntu /etc/logos
+RUN mkdir -p /etc/logos/blockchain /etc/logos/persistence && chown -R ubuntu:ubuntu /etc/logos
 
 USER ubuntu
 WORKDIR /home/ubuntu
 
 RUN mkdir packages \
-    && lgpd download logos-delivery-module --release build-20260422-1bfdb89-84 --output ./packages \
-    && lgpd download logos-storage-module --release build-20260422-1bfdb89-84 --output ./packages \
-    && lgpd download logos-blockchain-module --release build-20260422-1bfdb89-84 --output ./packages
+    && lgpd download delivery_module --version 1.1.0 --output ./packages \
+    && lgpd download storage_module --version 1.0.0 --output ./packages \
+    && lgpd download liblogos_blockchain_module --version 1.0.0 --output ./packages \
+    && lgpd download openmetrics --version 0.1.0 --output ./packages
 
 RUN mkdir modules \
     && lgpm install --dir ./packages --modules-dir ./modules
 
-CMD ["logoscore", "-D", "-m", "/home/ubuntu/modules"]
+CMD ["logoscore", "-D", "-m", "/home/ubuntu/modules", "--persistence-path", "/etc/logos/persistence"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ docker build -t logos .
 docker run logos
 ```
 
-The default `CMD` is `logoscore -D -m /home/ubuntu/modules`.
+The default `CMD` is `logoscore -D -m /home/ubuntu/modules --persistence-path /etc/logos/persistence`.
 
 ## What's inside
 
@@ -21,7 +21,9 @@ Three CLIs are installed and reachable on `$PATH`:
 - `lgpm` — Logos package manager
 - `lgpd` — Logos package downloader
 
-The image ships with the delivery, storage, and blockchain modules pre-installed under `/home/ubuntu/modules`.
+The image ships with the delivery, storage, and blockchain modules plus the
+[`openmetrics`](https://github.com/logos-co/openmetrics-module) scraper
+pre-installed under `/home/ubuntu/modules`.
 
 ## Runtime user and layout
 
@@ -30,11 +32,46 @@ The container runs as the unprivileged `ubuntu` user. `/app` is root-owned and h
 - `/home/ubuntu/packages/` — downloaded `.lgx` packages
 - `/home/ubuntu/modules/` — installed modules (passed to `logoscore` via `-m`)
 - `/etc/logos/blockchain/` — blockchain state written at runtime
+- `/etc/logos/persistence/` — logoscore module instance persistence (passed via `--persistence-path`)
 
-## Persisting blockchain state
+## Serving OpenMetrics
 
-Mount a named volume on `/etc/logos/blockchain` to keep state across container restarts:
+The bundled [`openmetrics`](https://github.com/logos-co/openmetrics-module)
+module serves a Prometheus-scrapeable `/metrics` endpoint. Run the container with
+the port published, load the modules, then load and `start` `openmetrics`:
 
 ```bash
-docker run -v logos-blockchain:/etc/logos/blockchain logos
+docker run -d -p 9090:9090 --name logos logos
+docker exec logos logoscore load-module delivery_module
+docker exec logos logoscore load-module storage_module
+docker exec logos logoscore load-module liblogos_blockchain_module
+docker exec logos logoscore load-module openmetrics
+docker exec logos logoscore call openmetrics start '{"port":9090,"modules":["delivery_module","storage_module","liblogos_blockchain_module"]}'
+curl http://localhost:9090/metrics
 ```
+
+For a complete, runnable walkthrough — build, run, load the modules, initialize
+`openmetrics`, and scrape `/metrics` from the host — see the doc-test in
+[`doctests/`](doctests/) ([rendered](doctests/outputs/openmetrics.md); run it with
+`cd doctests && ./run.sh`).
+
+## Persisting state across restarts
+
+Mount named volumes to keep state across container restarts:
+
+- `/etc/logos/blockchain` — blockchain state
+- `/etc/logos/persistence` — logoscore module instance data (`--persistence-path`)
+
+```bash
+docker run \
+  -v logos-blockchain:/etc/logos/blockchain \
+  -v logos-persistence:/etc/logos/persistence \
+  logos
+```
+
+Use **named volumes** (as above) rather than host bind mounts. The container runs
+as the unprivileged `ubuntu` user (uid 1000), and these paths are created
+`ubuntu`-owned in the image — so a fresh named volume inherits that ownership and
+is writable with no `chown`. A host bind mount instead keeps the host path's
+ownership, which may not be writable by the in-container `ubuntu` user; if you
+must bind-mount, `chown 1000:1000` the host directory first.

--- a/doctests/.gitignore
+++ b/doctests/.gitignore
@@ -1,0 +1,2 @@
+# Doc-test per-spec working directories — keep only the rendered reports.
+/outputs/*/

--- a/doctests/openmetrics.test.yaml
+++ b/doctests/openmetrics.test.yaml
@@ -1,0 +1,197 @@
+name: "Running the Logos image: load modules and serve OpenMetrics"
+output: openmetrics.md
+release: ""
+
+intro: |
+  The `logos-docker` image bundles the three Logos CLIs (`logoscore`, `lgpm`,
+  `lgpd`) and ships a set of modules pre-installed under
+  `/home/ubuntu/modules` — `delivery_module`, `storage_module`,
+  `liblogos_blockchain_module`, and the [`openmetrics`](https://github.com/logos-co/openmetrics-module)
+  scraper. The container's default `CMD` starts a `logoscore` daemon over that
+  modules directory; everything else is done by talking to that daemon.
+
+  This doc-test drives the image end-to-end:
+
+  1. **Build** the image and **run** it as a detached container, publishing the
+     OpenMetrics port so it is reachable from the host.
+  2. **Load** the bundled modules into the running daemon.
+  3. **Initialize** `openmetrics` — load it and `start` its HTTP server with a
+     config JSON naming the modules to scrape.
+  4. **Scrape** `/metrics` from outside the container and check `/health`.
+
+  > **About the metrics output.** `openmetrics` is a pure passthrough: on each
+  > scrape it calls every listed module's `collectMetrics()` and renders the
+  > aggregated result. None of the modules bundled in this image implement
+  > `collectMetrics()` yet, so `/metrics` currently serves only the OpenMetrics
+  > framing and ends with `# EOF` — no series. The moment a bundled module starts
+  > implementing `collectMetrics()`, its series appear here automatically with a
+  > `module="<name>"` label. For a worked provider example, see the
+  > [openmetrics-module doc-test](https://github.com/logos-co/openmetrics-module/tree/master/doctests).
+
+what_you_build: "The `logos-docker` image, run as a container with its OpenMetrics endpoint published to the host; the bundled modules loaded and `openmetrics` serving `/metrics`."
+
+what_you_learn:
+  - How to build and run the image from the Dockerfile in this repo
+  - How to publish the OpenMetrics port so the endpoint is reachable from outside the container
+  - How to load the pre-installed modules into the running `logoscore` daemon
+  - How to initialize `openmetrics` (`load-module` + `call openmetrics start`) and scrape `/metrics`
+
+prerequisites:
+  - "**Docker** — to build and run the image."
+  - "**curl** — to scrape the published endpoint from the host."
+  - "A network connection — the first build downloads the Nix builder layer and builds the CLIs, which can take several minutes."
+
+sections:
+  - title: "Build and run the image"
+    step: true
+    text: |
+      The image is built straight from this repo. The Dockerfile is a multi-stage
+      build: a `nixos/nix` stage builds the three CLIs as AppImages, and an
+      `ubuntu` stage extracts them, downloads the module packages with `lgpd`, and
+      installs them with `lgpm`. The default `CMD` is
+      `logoscore -D -m /home/ubuntu/modules --persistence-path /etc/logos/persistence`.
+    steps:
+      - title: "Build the image"
+        text: |
+          Build from the repo URL (the same command the README documents). The
+          doc-test runner pins the ref to the commit under test via
+          `$LOGOS_DOCKER_REF`.
+        run: |
+          docker build -t logos:doctest "https://github.com/logos-co/logos-docker.git#${LOGOS_DOCKER_REF:-master}"
+        code_block: |
+          docker build -t logos https://github.com/logos-co/logos-docker.git
+        post_text: "Confirm the image was built (it's a Linux image):"
+        extra_run:
+          run: "docker image inspect logos:doctest --format '{{.Os}}/{{.Architecture}}'"
+          code_block: "docker image inspect logos --format '{{.Os}}/{{.Architecture}}'"
+          expect_contains:
+            - "linux"
+
+      - title: "Run the container with the OpenMetrics port published"
+        text: |
+          Run it detached (`-d`) and publish the port `openmetrics` will listen on
+          (`-p 9090:9090`) so the endpoint is reachable from the host. The daemon
+          starts via the image's `CMD`.
+        run: "docker run -d -p 9090:9090 --name logos-doctest logos:doctest"
+        code_block: "docker run -d -p 9090:9090 --name logos logos"
+
+      - run: "sleep 5"
+
+      - title: "Confirm the daemon is up"
+        run: "docker exec logos-doctest logoscore status"
+        code_block: "docker exec logos logoscore status"
+        expect_contains:
+          - "running"
+
+  - title: "Load the modules"
+    step: true
+    text: |
+      The modules ship pre-installed under `/home/ubuntu/modules`. Loading a
+      module makes it live in the running daemon (dependencies are resolved
+      automatically).
+    steps:
+      - title: "List what's installed"
+        run: "docker exec logos-doctest lgpm --modules-dir /home/ubuntu/modules list"
+        code_block: "docker exec logos lgpm --modules-dir /home/ubuntu/modules list"
+        expect_contains:
+          - "delivery_module"
+          - "storage_module"
+          - "openmetrics"
+
+      - title: "Load the bundled modules"
+        run: |
+          docker exec logos-doctest logoscore load-module delivery_module
+          docker exec logos-doctest logoscore load-module storage_module
+          docker exec logos-doctest logoscore load-module liblogos_blockchain_module
+        code_block: |
+          docker exec logos logoscore load-module delivery_module
+          docker exec logos logoscore load-module storage_module
+          docker exec logos logoscore load-module liblogos_blockchain_module
+        expect_contains:
+          - "delivery_module"
+          - "storage_module"
+          - "liblogos_blockchain_module"
+
+  - title: "Initialize OpenMetrics"
+    step: true
+    text: |
+      Load the `openmetrics` module, then `start` its HTTP server with a config
+      JSON: the port to listen on and the modules to scrape. The JSON is passed as
+      a single argument so it reaches the module intact.
+    steps:
+      - title: "Load the openmetrics module"
+        run: "docker exec logos-doctest logoscore load-module openmetrics"
+        code_block: "docker exec logos logoscore load-module openmetrics"
+        expect_contains:
+          - "openmetrics"
+
+      - title: "Start the OpenMetrics server"
+        text: |
+          Bind it to `9090` — the port we published — so the endpoint is reachable
+          from the host. `start` returns `1` on success.
+        run: |
+          docker exec logos-doctest logoscore call openmetrics start '{"port":9090,"modules":["delivery_module","storage_module","liblogos_blockchain_module"]}'
+        code_block: |
+          docker exec logos logoscore call openmetrics start '{"port":9090,"modules":["delivery_module","storage_module","liblogos_blockchain_module"]}'
+        expect_contains:
+          - '"result":1'
+
+      - run: "sleep 1"
+
+      - title: "getInfo reports what it's serving"
+        text: |
+          `getInfo()` returns its status as a JSON string, so `logoscore` delivers
+          it as an escaped string inside the `result` field.
+        run: "docker exec logos-doctest logoscore call openmetrics getInfo"
+        code_block: "docker exec logos logoscore call openmetrics getInfo"
+        expect_contains:
+          - '\"running\":true'
+          - '\"port\":9090'
+
+  - title: "Scrape /metrics from the host"
+    step: true
+    text: |
+      Because the port is published, Prometheus — or a plain `curl` from the host
+      — can scrape the endpoint without entering the container.
+    steps:
+      - title: "Scrape /metrics"
+        text: |
+          The document is valid OpenMetrics and ends with `# EOF`. There are no
+          series yet because none of the bundled modules implement
+          `collectMetrics()` — once one does, its series appear here automatically.
+        run: "curl -s --max-time 15 http://localhost:9090/metrics"
+        code_block: "curl http://localhost:9090/metrics"
+        expect_contains:
+          - "# EOF"
+
+      - title: "Check /health"
+        run: "curl -s --max-time 5 http://localhost:9090/health"
+        code_block: "curl http://localhost:9090/health"
+        expect_contains:
+          - "ok"
+
+  - title: "Clean up"
+    step: true
+    text: |
+      Stop and remove the container (this also stops the daemon and the
+      OpenMetrics server inside it).
+    steps:
+      - title: "Remove the container"
+        run: "docker rm -f logos-doctest"
+        code_block: "docker rm -f logos"
+        expect_contains:
+          - "logos-doctest"
+
+  - title: "Recap"
+    text: |
+      | Step | Command | What it proves |
+      | ---- | ------- | -------------- |
+      | Build & run | `docker build` / `docker run -d -p 9090:9090` | the image builds and the daemon comes up with the metrics port published |
+      | Load | `logoscore load-module <name>` | the bundled modules load into the running daemon |
+      | Initialize | `logoscore call openmetrics start '{…}'` | `openmetrics` stands up its HTTP server on the published port |
+      | Scrape | `curl http://localhost:9090/metrics` | the endpoint is reachable from outside the container and serves valid OpenMetrics |
+
+      The `openmetrics` endpoint is now reachable from the host on `:9090`. Point a
+      Prometheus scrape at it, and as the bundled modules grow `collectMetrics()`
+      implementations their series will show up automatically, each labelled with
+      `module="<name>"`.

--- a/doctests/outputs/openmetrics.md
+++ b/doctests/outputs/openmetrics.md
@@ -1,0 +1,197 @@
+# Running the Logos image: load modules and serve OpenMetrics
+
+The `logos-docker` image bundles the three Logos CLIs (`logoscore`, `lgpm`,
+`lgpd`) and ships a set of modules pre-installed under
+`/home/ubuntu/modules` — `delivery_module`, `storage_module`,
+`liblogos_blockchain_module`, and the [`openmetrics`](https://github.com/logos-co/openmetrics-module)
+scraper. The container's default `CMD` starts a `logoscore` daemon over that
+modules directory; everything else is done by talking to that daemon.
+
+This doc-test drives the image end-to-end:
+
+1. **Build** the image and **run** it as a detached container, publishing the
+   OpenMetrics port so it is reachable from the host.
+2. **Load** the bundled modules into the running daemon.
+3. **Initialize** `openmetrics` — load it and `start` its HTTP server with a
+   config JSON naming the modules to scrape.
+4. **Scrape** `/metrics` from outside the container and check `/health`.
+
+> **About the metrics output.** `openmetrics` is a pure passthrough: on each
+> scrape it calls every listed module's `collectMetrics()` and renders the
+> aggregated result. None of the modules bundled in this image implement
+> `collectMetrics()` yet, so `/metrics` currently serves only the OpenMetrics
+> framing and ends with `# EOF` — no series. The moment a bundled module starts
+> implementing `collectMetrics()`, its series appear here automatically with a
+> `module="<name>"` label. For a worked provider example, see the
+> [openmetrics-module doc-test](https://github.com/logos-co/openmetrics-module/tree/master/doctests).
+
+**What you'll build:** The `logos-docker` image, run as a container with its OpenMetrics endpoint published to the host; the bundled modules loaded and `openmetrics` serving `/metrics`.
+
+**What you'll learn:**
+
+- How to build and run the image from the Dockerfile in this repo
+- How to publish the OpenMetrics port so the endpoint is reachable from outside the container
+- How to load the pre-installed modules into the running `logoscore` daemon
+- How to initialize `openmetrics` (`load-module` + `call openmetrics start`) and scrape `/metrics`
+
+## Prerequisites
+
+- **Docker** — to build and run the image.
+- **curl** — to scrape the published endpoint from the host.
+- A network connection — the first build downloads the Nix builder layer and builds the CLIs, which can take several minutes.
+
+---
+
+## Step 1: Build and run the image
+
+The image is built straight from this repo. The Dockerfile is a multi-stage
+build: a `nixos/nix` stage builds the three CLIs as AppImages, and an
+`ubuntu` stage extracts them, downloads the module packages with `lgpd`, and
+installs them with `lgpm`. The default `CMD` is
+`logoscore -D -m /home/ubuntu/modules --persistence-path /etc/logos/persistence`.
+
+### 1.1 Build the image
+
+Build from the repo URL (the same command the README documents). The
+doc-test runner pins the ref to the commit under test via
+`$LOGOS_DOCKER_REF`.
+
+```bash
+docker build -t logos https://github.com/logos-co/logos-docker.git
+```
+
+Confirm the image was built (it's a Linux image):
+
+```bash
+docker image inspect logos --format '{{.Os}}/{{.Architecture}}'
+```
+
+### 1.2 Run the container with the OpenMetrics port published
+
+Run it detached (`-d`) and publish the port `openmetrics` will listen on
+(`-p 9090:9090`) so the endpoint is reachable from the host. The daemon
+starts via the image's `CMD`.
+
+```bash
+docker run -d -p 9090:9090 --name logos logos
+```
+
+```bash
+sleep 5
+```
+
+### 1.3 Confirm the daemon is up
+
+```bash
+docker exec logos logoscore status
+```
+
+---
+
+## Step 2: Load the modules
+
+The modules ship pre-installed under `/home/ubuntu/modules`. Loading a
+module makes it live in the running daemon (dependencies are resolved
+automatically).
+
+### 2.1 List what's installed
+
+```bash
+docker exec logos lgpm --modules-dir /home/ubuntu/modules list
+```
+
+### 2.2 Load the bundled modules
+
+```bash
+docker exec logos logoscore load-module delivery_module
+docker exec logos logoscore load-module storage_module
+docker exec logos logoscore load-module liblogos_blockchain_module
+```
+
+---
+
+## Step 3: Initialize OpenMetrics
+
+Load the `openmetrics` module, then `start` its HTTP server with a config
+JSON: the port to listen on and the modules to scrape. The JSON is passed as
+a single argument so it reaches the module intact.
+
+### 3.1 Load the openmetrics module
+
+```bash
+docker exec logos logoscore load-module openmetrics
+```
+
+### 3.2 Start the OpenMetrics server
+
+Bind it to `9090` — the port we published — so the endpoint is reachable
+from the host. `start` returns `1` on success.
+
+```bash
+docker exec logos logoscore call openmetrics start '{"port":9090,"modules":["delivery_module","storage_module","liblogos_blockchain_module"]}'
+```
+
+```bash
+sleep 1
+```
+
+### 3.3 getInfo reports what it's serving
+
+`getInfo()` returns its status as a JSON string, so `logoscore` delivers
+it as an escaped string inside the `result` field.
+
+```bash
+docker exec logos logoscore call openmetrics getInfo
+```
+
+---
+
+## Step 4: Scrape /metrics from the host
+
+Because the port is published, Prometheus — or a plain `curl` from the host
+— can scrape the endpoint without entering the container.
+
+### 4.1 Scrape /metrics
+
+The document is valid OpenMetrics and ends with `# EOF`. There are no
+series yet because none of the bundled modules implement
+`collectMetrics()` — once one does, its series appear here automatically.
+
+```bash
+curl http://localhost:9090/metrics
+```
+
+### 4.2 Check /health
+
+```bash
+curl http://localhost:9090/health
+```
+
+---
+
+## Step 5: Clean up
+
+Stop and remove the container (this also stops the daemon and the
+OpenMetrics server inside it).
+
+### 5.1 Remove the container
+
+```bash
+docker rm -f logos
+```
+
+---
+
+## Recap
+
+| Step | Command | What it proves |
+| ---- | ------- | -------------- |
+| Build & run | `docker build` / `docker run -d -p 9090:9090` | the image builds and the daemon comes up with the metrics port published |
+| Load | `logoscore load-module <name>` | the bundled modules load into the running daemon |
+| Initialize | `logoscore call openmetrics start '{…}'` | `openmetrics` stands up its HTTP server on the published port |
+| Scrape | `curl http://localhost:9090/metrics` | the endpoint is reachable from outside the container and serves valid OpenMetrics |
+
+The `openmetrics` endpoint is now reachable from the host on `:9090`. Point a
+Prometheus scrape at it, and as the bundled modules grow `collectMetrics()`
+implementations their series will show up automatically, each labelled with
+`module="<name>"`.

--- a/doctests/run.sh
+++ b/doctests/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Execute the logos-docker openmetrics doc-test end-to-end and regenerate its Markdown.
+#
+# Spec:
+#   - openmetrics.test.yaml   builds the logos image from this repo, runs it with
+#                             the OpenMetrics port published, loads the bundled
+#                             modules, initializes openmetrics, and scrapes
+#                             /metrics from the host.
+#
+# The runner is the shared `doctest` CLI (https://github.com/logos-co/logos-doctest),
+# invoked directly via its flake. `doctest run` executes every command in a temp
+# directory and asserts on the output; `doctest generate` renders the spec to
+# Markdown under outputs/; `doctest clean` strips build artifacts.
+#
+# To run against a local logos-doctest checkout instead of the published flake,
+# set DOCTEST, e.g.:  DOCTEST="nix run path:../../logos-doctest --" ./run.sh
+#
+# Requires Docker and curl on the host.
+#
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# The doctest CLI. Override by exporting DOCTEST (space-separated command).
+read -r -a DOCTEST <<< "${DOCTEST:-nix run github:logos-co/logos-doctest --}"
+OUTPUT_DIR="./outputs"
+SPECS=(
+  "openmetrics.test.yaml"
+)
+
+# The spec builds `github:logos-co/logos-docker#${LOGOS_DOCKER_REF}` (a docker
+# build from the GitHub repo at this ref). Default to the current commit so a
+# local run tests exactly what's checked out.
+#
+# Note: docker fetches the ref from the GitHub remote, so $LOGOS_DOCKER_REF must
+# be pushed. A local-only / uncommitted HEAD won't resolve; export
+# LOGOS_DOCKER_REF=master (or push first) in that case.
+export LOGOS_DOCKER_REF="${LOGOS_DOCKER_REF:-$(git rev-parse HEAD)}"
+echo "==> Building image from logos-docker ref ${LOGOS_DOCKER_REF}"
+
+# Remove any container left over from a previous run so --name doesn't collide.
+docker rm -f logos-doctest >/dev/null 2>&1 || true
+
+echo "==> Clearing previous ${OUTPUT_DIR}/"
+if [ -e "${OUTPUT_DIR}" ]; then
+  chmod -R u+w "${OUTPUT_DIR}" 2>/dev/null || true
+fi
+rm -rf "${OUTPUT_DIR}"
+mkdir -p "${OUTPUT_DIR}"
+
+for SPEC in "${SPECS[@]}"; do
+  name="$(basename "${SPEC%.test.yaml}")"
+  spec_out="${OUTPUT_DIR}/${name}"
+  mkdir -p "${spec_out}"
+
+  echo "==> Running ${SPEC} into ${spec_out}/"
+  "${DOCTEST[@]}" run "${SPEC}" \
+    --verbose \
+    --continue-on-fail \
+    --output-dir "${spec_out}/"
+
+  echo "==> Generating ${OUTPUT_DIR}/${name}.md"
+  "${DOCTEST[@]}" generate "${SPEC}" \
+    -o "${OUTPUT_DIR}/${name}.md"
+done
+
+echo "==> Cleaning build artifacts from ${OUTPUT_DIR}/"
+"${DOCTEST[@]}" clean "${OUTPUT_DIR}" --verbose
+
+echo "==> Done. Rendered docs are in ${OUTPUT_DIR}/"


### PR DESCRIPTION
## Summary

- **Bump** the `logoscore`, `lgpm`, and `lgpd` CLI pins and the module package versions.
- **Add the `openmetrics` module** to the image (downloaded + installed alongside delivery/storage/blockchain), so the node can serve a Prometheus-scrapeable `/metrics` endpoint.
- **Add a doc-test** (`doctests/`) that builds and runs the image, loads the modules, initializes `openmetrics`, and scrapes `/metrics` from the host — runnable via `cd doctests && ./run.sh`, rendered at `doctests/outputs/openmetrics.md`.
- **Add a persistence volume** for `logoscore`'s module-instance state: the default `CMD` now passes `--persistence-path /etc/logos/persistence`, the dir is created `ubuntu`-owned in the image, and the README documents mounting a named volume there.

## Notes

- The `lgpd` pin (`172a518`) includes the `--version` parser fix from logos-package-downloader#6. Without it, `lgpd download <pkg> --version <ver>` printed the version banner and exited 0 without downloading, so `lgpm install` failed with *"No .lgx files found"* and the image build broke. The bump and that fix go together.
- None of the bundled modules implement `collectMetrics()` yet, so `/metrics` currently serves only the OpenMetrics framing (`# EOF`); series appear automatically once a module implements it. The doc-test asserts the operational flow, not specific series.

## Validated locally (end-to-end)

- Image builds clean (`docker build`): all four packages download with pinned versions, `Installed 4/4 package(s)`.
- Doc-test flow against the live container: modules load, `openmetrics start` → `"result":1`, `getInfo` → `running:true`/`port:9090`, `curl /metrics` from the **host** → `# EOF`, `/health` → `ok`.
- Persistence volume: daemon runs as `uid=1000(ubuntu)`; `/etc/logos/persistence` and a fresh named volume are both `ubuntu`-owned and writable (no `chown` needed); the daemon writes per-module state there, and it survives container replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)